### PR TITLE
Update Fractal's website URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -229,11 +229,13 @@ emoji = 'Fractal?'
 name = 'fractal'
 title = 'Fractal'
 description = 'Matrix messaging app for GNOME written in Rust.'
-website = 'https://gitlab.gnome.org/GNOME/fractal'
+website = 'https://gitlab.gnome.org/World/fractal'
 default_section = 'clients'
 usual_reporters = [
     '@afranke:matrix.org',
-    '@jsparber:gnome.org']
+    '@jsparber:gnome.org',
+    '@zecakeh:tedomum.net',
+]
 
 [[projects]]
 emoji = 'FluffyChat?'


### PR DESCRIPTION
The repository was moved in the GNOME GitLab instance. Also add myself as a reporter.