### PR TITLE
Auto-generate more of the report `path`

### DIFF
--- a/charts/files/report_template.md
+++ b/charts/files/report_template.md
@@ -1,7 +1,7 @@
 +++
 date = "{{today}}"
 title = "This Week in Matrix {{today}}"
-path = "/blog/YYYY/MM/DD/this-week-in-matrix-YYYY-MM-DD"
+path = "/blog/YYYY/MM/DD/this-week-in-matrix-{{today}}"
 
 [taxonomies]
 author = ["{{author}}"]


### PR DESCRIPTION
This could be automated. Is it specifically not? Of course the rest of the path is still manual

Signed-off-by: HarHarLinks <2803622+HarHarLinks@users.noreply.github.com>