### PR TITLE
Rory&::LibMatrix: .NET 9 -> .NET 10

### DIFF
--- a/charts/files/config.toml
+++ b/charts/files/config.toml
@@ -1486,12 +1486,11 @@ usual_reporters = [
 emoji = 'Rory&::LibMatrix'
 name = 'rory-libmatrix'
 title = 'Rory&::LibMatrix'
-description = '.NET 9 Matrix bot/client library/SDK.'
+description = '.NET 10 Matrix bot/client library/SDK.'
 website = 'https://cgit.rory.gay/matrix/LibMatrix.git/'
 default_section = 'sdks'
 usual_reporters = [
   '@emma:rory.gay',
-  '@emma:conduit.rory.gay',
 ]
 
 [[projects]]


### PR DESCRIPTION
Bumps the .NET version to .NET 10 for Rory&::LibMatrix, as that's being released in a few weeks and is marked as Go Live-ready.

Signed-off-by: Rory& <<root@rory.gay>>